### PR TITLE
added missing statements for wkt parsing

### DIFF
--- a/src/Proj.php
+++ b/src/Proj.php
@@ -497,6 +497,12 @@ class Proj
                     case 'latitude_of_origin':
                         $this->lat0 = $value * Common::D2R;
                         break;
+                    case 'standard_parallel_1':
+                        $this->lat1 = $value * Common::D2R;
+                        break;
+                    case 'standard_parallel_2':
+                        $this->lat2 = $value * Common::D2R;
+                        break;
                     case 'more_here':
                         break;
                     default:


### PR DESCRIPTION
This appears to fix the the first projection definition 
```
PROJCS["Belge 1972 / Belgian Lambert 72",GEOGCS["Belge 1972",DATUM["Reseau_National_Belge_1972",SPHEROID["International 1924",6378388,297,AUTHORITY["EPSG","7022"]],TOWGS84[106.869,-52.2978,103.724,-0.33657,0.456955,-1.84218,1],AUTHORITY["EPSG","6313"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4313"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",51.16666723333333],PARAMETER["standard_parallel_2",49.8333339],PARAMETER["latitude_of_origin",90],PARAMETER["central_meridian",4.367486666666666],PARAMETER["false_easting",150000.013],PARAMETER["false_northing",5400088.438],AUTHORITY["EPSG","31370"],AXIS["X",EAST],AXIS["Y",NORTH]]
```
from @coreation in issue #17 

here is my modified unit test that checks transform values 

```

public function testInlineProjectionMethod2()
    {
        $proj4           = new Proj4php();

        $projWGS84       = new Proj('EPSG:4326', $proj4);
        $projOSGB36      = new Proj('PROJCS["OSGB 1936 / British National Grid",GEOGCS["OSGB 1936",DATUM["OSGB_1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],AUTHORITY["EPSG","6277"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4277"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",49],PARAMETER["central_meridian",-2],PARAMETER["scale_factor",0.9996012717],PARAMETER["false_easting",400000],PARAMETER["false_northing",-100000],AUTHORITY["EPSG","27700"],AXIS["Easting",EAST],AXIS["Northing",NORTH]]',$proj4);
        $pointSrc = new Point(671196.3657,1230275.0454,$projOSGB36);
        
        $projLCC2SP=new Proj('PROJCS["Belge 1972 / Belgian Lambert 72",GEOGCS["Belge 1972",DATUM["Reseau_National_Belge_1972",SPHEROID["International 1924",6378388,297,AUTHORITY["EPSG","7022"]],TOWGS84[106.869,-52.2978,103.724,-0.33657,0.456955,-1.84218,1],AUTHORITY["EPSG","6313"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4313"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Lambert_Conformal_Conic_2SP"],PARAMETER["standard_parallel_1",51.16666723333333],PARAMETER["standard_parallel_2",49.8333339],PARAMETER["latitude_of_origin",90],PARAMETER["central_meridian",4.367486666666666],PARAMETER["false_easting",150000.013],PARAMETER["false_northing",5400088.438],AUTHORITY["EPSG","31370"],AXIS["X",EAST],AXIS["Y",NORTH]]',$proj4);
        $pointLCC2SP=$proj4->transform($projLCC2SP, $pointSrc);
        
        // check known conversion value for WGS84
        $pointWGS84 =$proj4->transform($projWGS84, $pointLCC2SP);
        $this->assertEquals(2.9964931538756, $pointWGS84->x, '', 0.1);
        $this->assertEquals(60.863435314163, $pointWGS84->y, '', 0.1);

        // check known convertion value for OSGB36
        $pointOSGB36 =$proj4->transform($projOSGB36, $pointLCC2SP);
        $this->assertEquals(671196.3657, $pointOSGB36->x, '', 20);
        $this->assertEquals(1230275.0454, $pointOSGB36->y, '', 20);
   

    }

```