### PR TITLE
added the rest of the missing proj definitions and updates to pass sp…

### DIFF
--- a/src/Proj.php
+++ b/src/Proj.php
@@ -541,14 +541,14 @@ class Proj
                         $this->k0 = $value;
                         break;
                     case 'central_meridian':
-                    case 'longitude_of_center'; // SR-ORG:10
+                    case 'longitude_of_center': // SR-ORG:10
                         $this->longc = $value * $this->to_rads;
-                    case 'longitude_of_origin'; // SR-ORG:118
+                    case 'longitude_of_origin': // SR-ORG:118
                         $this->long0 = $value * $this->to_rads;
 
                         break;
                     case 'latitude_of_origin':
-                    case 'latitude_of_center'; // SR-ORG:10
+                    case 'latitude_of_center': // SR-ORG:10
                         $this->lat0 = $value * $this->to_rads;
                         if($this->projName=='merc'||$this->projName=='eqc'
                             ){
@@ -648,6 +648,7 @@ class Proj
 
                     case 'easting':
                     case 'northing':
+                    case 'southing': //SR-ORG:8262
                         break;
                     
                     default : 
@@ -698,7 +699,12 @@ class Proj
             $wktName=="Kilometer" ||
             $wktName=="international_feet" ||
             $wktName=="m" ||
-            $wktName=="Mile_US"
+            $wktName=="Mile_US" ||
+            $wktName=="Coord" ||
+            $wktName=="Indian yard"||
+            $wktName=="British yard (Sears 1922)" ||
+            $wktName=="British chain (Sears 1922)" ||
+            $wktName=="British foot (Sears 1922)"
             ){
 
             //$wktName=="1/32meter" = 0.03125 SR-ORG:98 ? should we support this?
@@ -722,7 +728,11 @@ class Proj
             // SR-ORG:7677 Foot
             // SR-ORG:7753 m = 9000.0
             // SR-ORG:7889 Mile_US
-
+            // SR-ORG:8262 Coord = 0.0746379
+            // EPSG:24370 Indian yard 0.9143985307444408
+            // EPSG:27291 British yard (Sears 1922) 0.9143984146160287
+            // EPSG:29871 British chain (Sears 1922) 20.11676512155263,
+            // EPSG:29872 British foot (Sears 1922) 0.3047994715386762,
             $this->to_meter= floatval( array_shift($wktArray));
             if(isset($this->x0)){
                     $this->x0=$this->to_meter*$this->x0;
@@ -737,10 +747,12 @@ class Proj
     protected function parseWKTToRads($wktName, &$wktArray){
         if($wktName=='Radian'||
             $wktName=='Degree' ||
-            $wktName=='degree'
+            $wktName=='degree' ||
+            $wktName=='grad'
             ){
 
             // SR-ORG:7753 degree=0.081081
+            // SR-ORG:8163 grad=0.01570796326794897,
 
             $this->to_rads= floatval( array_shift($wktArray));
             if(isset($this->lat_ts)){
@@ -1029,6 +1041,7 @@ class Proj
             $this->sphere = true;
             $this->b = $this->a;
         }
+
 
         // used in geocentric
         $this->a2 = $this->a * $this->a;

--- a/src/Proj4php.php
+++ b/src/Proj4php.php
@@ -153,6 +153,9 @@ class Proj4php
         self::$wktProjections["Miller_Cylindrical"]="mill"; //SR-ORG:8064
         self::$wktProjections["Equidistant_Conic"]="eqdc"; //SR-ORG:8159
 
+        self::$wktProjections['Hotine_Oblique_Mercator_Two_Point_Natural_Origin']='omerc'; //ESRI:53025
+        self::$wktProjections['VanDerGrinten']='vandg'; //ESRI:53029
+
         
     }
 
@@ -161,6 +164,7 @@ class Proj4php
       self::$wktEllipsoids["Clarke 1880 (RGS)"] = "clrk80"; //EPSG:2000
       self::$wktEllipsoids["Clarke_1880_RGS"]="clrk80"; //SR-ORG:7244
       self::$wktEllipsoids["Clarke_1866"]= "clrk66"; //SR-ORG:11
+      self::$wktEllipsoids['Clarke 1880']="clrk80"; //EPSG:62416405
       //self::$wktEllipsoids["Krasovsky_1940"]="krass"; //SR-ORG:7191
       //self::$wktEllipsoids["WGS 84"]="WGS84"; //SR-ORG:62
 
@@ -177,7 +181,10 @@ class Proj4php
       self::$wktDatums["North American Datum 1927"]="NAD27";
       self::$wktDatums["Deutsches_Hauptdreiecksnetz"]="potsdam";//EPSG:3068
       self::$wktDatums["New_Zealand_Geodetic_Datum_1949"]="nzgd49";//EPSG:4272
-      self::$wktDatums["OSGB_1936"]="OSGB36"; //EPSG:4277
+      self::$wktDatums["OSGB_1936"]="OSGB36"; // EPSG:4277
+      self::$wktDatums["New Zealand Geodetic Datum 1949"]="nzgd49"; //EPSG:62726405
+      self::$wktDatums["OSGB 1936"]="OSGB36"; // EPSG:62776405
+      self::$wktDatums["Deutsches Hauptdreiecksnetz"]="potsdam"; // EPSG:63146405
 
 
     }

--- a/src/projCode/Eqc.php
+++ b/src/projCode/Eqc.php
@@ -17,18 +17,24 @@ class Eqc
 {
     public function init() {
 
-        if( !$this->x0 )
+        if( !$this->x0 ){
             $this->x0 = 0;
-        if( !$this->y0 )
+        }
+        if( !$this->y0 ){
             $this->y0 = 0;
-        if( !$this->lat0 )
+        }
+        if( !isset($this->lat0)){
             $this->lat0 = 0;
-        if( !$this->long0 )
+        }
+        if( !$this->long0 ){
             $this->long0 = 0;
-        if( !$this->lat_ts )
+        }
+        if( !$this->lat_ts ){
             $this->lat_ts = 0;
-        if( !$this->title )
+        }
+        if( !$this->title ){
             $this->title = "Equidistant Cylindrical (Plate Carre)";
+        }
 
         $this->rc = cos( $this->lat_ts );
     }

--- a/src/projCode/Omerc.php
+++ b/src/projCode/Omerc.php
@@ -56,9 +56,12 @@ class Omerc
         if(!isset($this->lat2)){
             $this->lat2 = 0;
         }
-        // if(!isset($this->longc)){
-        //     $this->longc = 0;
-        // }
+        if(!isset($this->alpha)){
+            $this->alpha=0;
+        }
+         if(!isset($this->longc)){
+             $this->longc = 0;
+        }
         // $this->f=1.0;
 
         /* Place parameters in static storage for common use


### PR DESCRIPTION
added aditional updates so that SpatialreferenceTest loads and tests all proj4 and wkt codes in the entire spatialref database. all tests pass, however there are a number of items that should be tested, but are currently ignored:

-proj4 codes using utm where wkt uses tmerc
-a bunch of IAU2000 prefixed codes where wkt has long0=pi but proj4 sets this to 0
-axis mismatches

other things are ignored that can't be tested:
-projection algoritms not defined by proj4php
-nonsensical wkt definitions (black listed)

alot of the updated to proj.php and proj4php.php could be cleaned up. but i just wanted to get through the entire set of codes first.