### PR TITLE
Some defs not properly defined

### DIFF
--- a/src/defs/EPSG26912.php
+++ b/src/defs/EPSG26912.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "EPSG26912" => "+title=NAD83 / UTM zone 12N +proj=utm +zone=12 +a=6378137.0 +b=6356752.3141403",
+    "EPSG:26912" => "+title=NAD83 / UTM zone 12N +proj=utm +zone=12 +a=6378137.0 +b=6356752.3141403",
 ];

--- a/src/defs/EPSG3785.php
+++ b/src/defs/EPSG3785.php
@@ -3,5 +3,5 @@
 // Same as EPSG:3875
 
 return [
-    "+title=Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
+    "EPSG:3785" => "+title=Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
 ];

--- a/src/defs/EPSG3857.php
+++ b/src/defs/EPSG3857.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "+title= Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
+    "EPSG:3857" => "+title= Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
 ];

--- a/src/defs/EPSG4269.php
+++ b/src/defs/EPSG4269.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "+title=long/lat:NAD83 +proj=longlat +a=6378137.0 +b=6356752.31414036 +ellps=GRS80 +datum=NAD83 +units=degrees",
+    "EPSG:4269" => "+title=long/lat:NAD83 +proj=longlat +a=6378137.0 +b=6356752.31414036 +ellps=GRS80 +datum=NAD83 +units=degrees",
 ];

--- a/src/defs/EPSG4326.php
+++ b/src/defs/EPSG4326.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "+title=long/lat:WGS84 +proj=longlat +a=6378137.0 +b=6356752.31424518 +ellps=WGS84 +datum=WGS84 +units=degrees",
+    "EPSG:4326" => "+title=long/lat:WGS84 +proj=longlat +a=6378137.0 +b=6356752.31424518 +ellps=WGS84 +datum=WGS84 +units=degrees",
 ];

--- a/src/defs/WGS84.php
+++ b/src/defs/WGS84.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    "+title=long/lat:WGS84 +proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees",
+    "WSG84" => "+title=long/lat:WGS84 +proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees",
 ];


### PR DESCRIPTION
Some defs are not properly defined:

each definition is an array, where the definition name is the key and the definition is the array. For some definitions no key is defined. E.g. for EPSG3857.php:
```php
<?php

// Same as EPSG:3875

return [
    "+title=Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
];
```

But should be 
```php
<?php

// Same as EPSG:3875

return [
   "EPSG:3857" => "+title=Google Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs",
];
```

Right now I get the error Exception: Proj4php initialization for: EPSG:3857 not yet complete in proj4php\Proj4php::reportError() every time