### PR TITLE
Fix variable names in Nzmg projection code.

### DIFF
--- a/src/projCode/Nzmg.php
+++ b/src/projCode/Nzmg.php
@@ -290,12 +290,12 @@ class Nzmg
             $num_re = $z_re;
             $num_im = $z_im;
             for( $n = 2; $n <= 6; $n++ ) {
-                $th_n_re1 = $th_n_re * th_re - $th_n_im * $th_im;
+                $th_n_re1 = $th_n_re * $th_re - $th_n_im * $th_im;
                 $th_n_im1 = $th_n_im * $th_re + $th_n_re * $th_im;
                 $th_n_re = $th_n_re1;
                 $th_n_im = $th_n_im1;
                 $num_re = $num_re + ($n - 1) * ($this->B_re[$n] * $th_n_re - $this->B_im[$n] * $th_n_im);
-                $num_im = $num_im + (n - 1) * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
+                $num_im = $num_im + ($n - 1) * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
             }
 
             $th_n_re = 1;
@@ -308,7 +308,7 @@ class Nzmg
                 $th_n_re = $th_n_re1;
                 $th_n_im = $th_n_im1;
                 $den_re = $den_re + $n * ($this->B_re[$n] * $th_n_re - $this->B_im[$n] * $th_n_im);
-                $den_im = $den_im + $n * ($this->B_im[n] * $th_n_re + $this->B_re[$n] * $th_n_im);
+                $den_im = $den_im + $n * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
             }
 
             // Complex division


### PR DESCRIPTION
**Thanks for this library!**

I tried to use proj4php to convert coordinates from EPSG:27200 to WGS84. I got some errors about variables in src/projCode/Nzmg.php being undefined.

I updated that file to have a $ in front of the variable names where needed, and it seems to have fixed the errors, as well as giving correct coordinates.

Example point in EPSG:27200

	6409770.613969509 2701435.4371613124
	
Expected coordinates in WGS84 (using http://apps.linz.govt.nz/coordinate-conversion/)

	175.16210956 -37.49395940

Coordinates from proj4php before code changes:

	174.95843670309 -37.588069734386

Which is quite a bit off from the expected coordinates.

Coordinates from proj4php after code changes:

	175.16209455838 -37.493961467272
	
Which is much closer to the coordinates from the online conversion tool.