### PR TITLE
Issue61test

### DIFF
--- a/src/projCode/Nzmg.php
+++ b/src/projCode/Nzmg.php
@@ -290,12 +290,12 @@ class Nzmg
             $num_re = $z_re;
             $num_im = $z_im;
             for( $n = 2; $n <= 6; $n++ ) {
-                $th_n_re1 = $th_n_re * th_re - $th_n_im * $th_im;
+                $th_n_re1 = $th_n_re * $th_re - $th_n_im * $th_im;
                 $th_n_im1 = $th_n_im * $th_re + $th_n_re * $th_im;
                 $th_n_re = $th_n_re1;
                 $th_n_im = $th_n_im1;
                 $num_re = $num_re + ($n - 1) * ($this->B_re[$n] * $th_n_re - $this->B_im[$n] * $th_n_im);
-                $num_im = $num_im + (n - 1) * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
+                $num_im = $num_im + ($n - 1) * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
             }
 
             $th_n_re = 1;
@@ -308,7 +308,7 @@ class Nzmg
                 $th_n_re = $th_n_re1;
                 $th_n_im = $th_n_im1;
                 $den_re = $den_re + $n * ($this->B_re[$n] * $th_n_re - $this->B_im[$n] * $th_n_im);
-                $den_im = $den_im + $n * ($this->B_im[n] * $th_n_re + $this->B_re[$n] * $th_n_im);
+                $den_im = $den_im + $n * ($this->B_im[$n] * $th_n_re + $this->B_re[$n] * $th_n_im);
             }
 
             // Complex division

--- a/test/Proj4phpTest.php
+++ b/test/Proj4phpTest.php
@@ -15,6 +15,7 @@ class Proj4phpTest extends \PHPUnit_Framework_TestCase
     public function testTransform()
     {
         $proj4     = new Proj4php();
+
         $projL93   = new Proj('EPSG:2154', $proj4);
         $projWGS84 = new Proj('EPSG:4326', $proj4);
         $projLI    = new Proj('EPSG:27571', $proj4);
@@ -30,6 +31,7 @@ class Proj4phpTest extends \PHPUnit_Framework_TestCase
         $proj3826 = new Proj('EPSG:3826', $proj4); //TWD97 / TM2 zone 121
         $proj3827 = new Proj('EPSG:3827', $proj4); //TWD67 / TM2 zone 119
         $proj3828 = new Proj('EPSG:3828', $proj4); //TWD67 / TM2 zone 121
+        $proj27200 = new Proj('EPSG:27200', $proj4); // PR #61
 
         // GPS
         // latitude        longitude
@@ -97,27 +99,34 @@ class Proj4phpTest extends \PHPUnit_Framework_TestCase
 
         $pointSrc = $pointDest;
         $pointDest = $proj4->transform($projWGS84,$proj3825,$pointSrc);
-        
+
         // TWD97 / TM2 zone 121
         $pointSrc = new Point('248170.787','2652129.936');
         $pointDest = $proj4->transform($proj3826,$projWGS84,$pointSrc);
 
         $pointSrc = $pointDest;
         $pointDest = $proj4->transform($projWGS84,$proj3826,$pointSrc);
-        
+
         // TWD67 / TM2 zone 119
         $pointSrc = new Point('170900', '2701500');
         $pointDest = $proj4->transform($proj3827,$projWGS84,$pointSrc);
 
         $pointSrc = $pointDest;
         $pointDest = $proj4->transform($projWGS84,$proj3827,$pointSrc);
-        
+
         // TWD67 / TM2 zone 121
         $pointSrc = new Point('247342.198','2652335.851');
         $pointDest = $proj4->transform($proj3828,$projWGS84,$pointSrc);
 
         $pointSrc = $pointDest;
         $pointDest = $proj4->transform($projWGS84,$proj3828,$pointSrc);
+
+        // For Issue #61
+        $pointSrc = new Point('6409770.613969509', '2701435.4371613124');
+        $pointDest = $proj4->transform($proj27200,$projWGS84,$pointSrc);
+
+        $pointSrc = $pointDest;
+        $pointDest = $proj4->transform($projWGS84,$proj27200,$pointSrc);
     }
 
     /**

--- a/test/SpatialreferenceTest.php
+++ b/test/SpatialreferenceTest.php
@@ -5,7 +5,7 @@ use proj4php\Point;
 use proj4php\Proj4php;
 use proj4php\Proj;
 
-error_reporting(E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 class SpatialreferenceTest extends PHPUnit_Framework_TestCase

--- a/test/WktParserTest.php
+++ b/test/WktParserTest.php
@@ -2,7 +2,7 @@
 include dirname(__DIR__) . "/src/Wkt.php";
 
 
-error_reporting(E_STRICT);
+error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 use proj4php\Wkt;


### PR DESCRIPTION
PR #61 with a test.

The `E_STRICT` error level set previously was masking the reported error, since setting `E_STRICT` alone was excluding ALL other error levels. From PHP 5.4 `E_STRICT` is included in `E_ALL`.