### PR TITLE
remove call of unknown function float()

### DIFF
--- a/src/Common.php
+++ b/src/Common.php
@@ -294,7 +294,7 @@ class Common
     public static function latiso($eccent, $phi, $sinphi)
     {
         if (abs($phi) > M_PI_2) {
-            return float(NAN);
+            return NAN;
         }
 
         if ($phi == M_PI_2) {


### PR DESCRIPTION
The term "float(NAN)" is not correct, because there is no such function. There is only floatval(), but this is needless because NAN is already of type float.
```php
var_dump(NAN);
```

will give

```
float(NAN)
```